### PR TITLE
Add hidedir command and improve reset methods

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -66,7 +66,8 @@
 	eucjpdfs = eucjpdiffs
 
 	### reset methods
-	uncommit    = reset --soft HEAD^  # HEAD^ and HEAD~1 are equivalent (one commit back)
+	# HEAD^ and HEAD~1 are equivalent (one commit back)
+	uncommit    = reset --soft HEAD^
 	unstage     = reset HEAD
 	abort-merge = merge --abort
 

--- a/gitconfig
+++ b/gitconfig
@@ -51,6 +51,9 @@
 	dfs = diff --cached
 	dfn = diff --name-only
 
+	### git-hidedir (original command)
+	hd = hidedir
+
 	piconvdiff = "!function f { enc=$1 ; shift ; git diff --color=always \"$@\" | piconv -f $enc -t utf8;}; f"
 	sjisdiff = piconvdiff shiftjis
 	eucjpdiff = piconvdiff euc-jp
@@ -63,9 +66,9 @@
 	eucjpdfs = eucjpdiffs
 
 	### reset methods
-	cancel      = reset --soft HEAD^
-	reset-merge = reset --merge
+	uncommit    = reset --soft HEAD^  # HEAD^ and HEAD~1 are equivalent (one commit back)
 	unstage     = reset HEAD
+	abort-merge = merge --abort
 
 	# see: http://ikeyasu.hatenablog.com/entries/2011/05/25
 	# http://qiita.com/peccul/items/90dd469e2f72babbc106


### PR DESCRIPTION
Introduce a new `hidedir` command to the git configuration and enhance the reset methods for better usability.

Currently `hidedir` command is not published as open. This work is planned, but still planning.