### PR TITLE
Remove exit code from prompt in VSCode

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -32,7 +32,7 @@ function is_kde { test -n "$KDE_FULL_SESSION" && test "$KDE_FULL_SESSION" = true
 
 function is_cursor_local { test -n "$CURSOR_TRACE_ID" ; }
 function is_cursor_codespaces { [[ $BROWSER =~ cursor-server ]] ; }
-function is_vscode_local { test "$TERM_PROGRAM" = "vscode" ; }
+function is_vscode_local { [[ $TERM_PROGRAM == vscode ]] ; }
 
 # bkt - https://github.com/dimo414/bkt
 # Cache commands using bkt if installed

--- a/bash_aliases
+++ b/bash_aliases
@@ -32,6 +32,7 @@ function is_kde { test -n "$KDE_FULL_SESSION" && test "$KDE_FULL_SESSION" = true
 
 function is_cursor_local { test -n "$CURSOR_TRACE_ID" ; }
 function is_cursor_codespaces { [[ $BROWSER =~ cursor-server ]] ; }
+function is_vscode_local { test "$TERM_PROGRAM" = "vscode" ; }
 
 # bkt - https://github.com/dimo414/bkt
 # Cache commands using bkt if installed

--- a/zshrc
+++ b/zshrc
@@ -55,7 +55,12 @@ if [ "$TERM" = screen ] ; then
 fi
 
 #PROMPT="%F{black}%1(?.%K{red}.%K{green})↪%?%k%f @%T $PROMPT"
-prompt_rc="%F{black}%1(?.%K{red}.%K{green})↪%?%k%f"
+# Remove exit code from prompt when in VSCode
+if is_vscode_local ; then
+    prompt_rc=""
+else
+    prompt_rc="%F{black}%1(?.%K{red}.%K{green})↪%?%k%f"
+fi
 prompt_dt="%F{white}%K{blue}%T%k%f"
 #prompt_jc="%F{black}%1(j.%K{magenta}.%K{white})&%j%k%f"
 prompt_jc="%1(j.%F{black}%K{cyan}&%j%k%f .)"


### PR DESCRIPTION
When the shell is running in VSCode, the exit code is removed from the prompt to enhance user experience. The `is_vscode_local` function now uses pattern matching to identify the environment. Fixes #8